### PR TITLE
Closes #11 Mark as duplicate of issue #231: Data versioning conflicts

### DIFF
--- a/__run_exp8/AllTwosSequenceTests.cs
+++ b/__run_exp8/AllTwosSequenceTests.cs
@@ -1,0 +1,14 @@
+using Algorithms.Sequences;
+
+namespace Algorithms.Tests.Sequences;
+
+public class AllTwosSequenceTests
+{
+    [Test]
+    public void First10ElementsCorrect()
+    {
+        var sequence = new AllTwosSequence().Sequence.Take(10);
+        sequence.SequenceEqual(new BigInteger[] { 2, 2, 2, 2, 2, 2, 2, 2, 2, 2 })
+            .Should().BeTrue();
+    }
+}

--- a/__run_exp8/exponentiation.t.sol
+++ b/__run_exp8/exponentiation.t.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.0;
+
+import "forge-std/Test.sol";
+import "../exponentiation.sol";
+
+contract ExponentiationTest is Test {
+    // Target contract
+    Exponentiation exponentiation;
+
+    /// Test Params
+    uint16 firstNo = 2;
+    uint16 secondNo = 2;
+
+    //  =====   Set up  =====
+    function setUp() public {
+        exponentiation = new Exponentiation();
+        exponentiation.firstNoSet(firstNo);
+        exponentiation.secondNoSet(secondNo);
+    }
+
+    /// @dev Test `Expo`
+
+    function test_GetModulo() external {
+        uint256 result = exponentiation.Expo();
+        uint256 expected = 2**2;
+        assertEq(expected, result);
+    }
+}

--- a/__run_exp8/rabin_karp.rs
+++ b/__run_exp8/rabin_karp.rs
@@ -1,0 +1,123 @@
+//! This module implements the Rabin-Karp string searching algorithm.
+//! It uses a rolling hash technique to find all occurrences of a pattern
+//! within a target string efficiently.
+
+const MOD: usize = 101;
+const RADIX: usize = 256;
+
+/// Finds all starting indices where the `pattern` appears in the `text`.
+///
+/// # Arguments
+/// * `text` - The string where the search is performed.
+/// * `pattern` - The substring pattern to search for.
+///
+/// # Returns
+/// A vector of starting indices where the pattern is found.
+pub fn rabin_karp(text: &str, pattern: &str) -> Vec<usize> {
+    if text.is_empty() || pattern.is_empty() || pattern.len() > text.len() {
+        return vec![];
+    }
+
+    let pat_hash = compute_hash(pattern);
+    let mut radix_pow = 1;
+
+    // Compute RADIX^(n-1) % MOD
+    for _ in 0..pattern.len() - 1 {
+        radix_pow = (radix_pow * RADIX) % MOD;
+    }
+
+    let mut rolling_hash = 0;
+    let mut result = vec![];
+    for i in 0..=text.len() - pattern.len() {
+        rolling_hash = if i == 0 {
+            compute_hash(&text[0..pattern.len()])
+        } else {
+            update_hash(text, i - 1, i + pattern.len() - 1, rolling_hash, radix_pow)
+        };
+        if rolling_hash == pat_hash && pattern[..] == text[i..i + pattern.len()] {
+            result.push(i);
+        }
+    }
+    result
+}
+
+/// Calculates the hash of a string using the Rabin-Karp formula.
+///
+/// # Arguments
+/// * `s` - The string to calculate the hash for.
+///
+/// # Returns
+/// The hash value of the string modulo `MOD`.
+fn compute_hash(s: &str) -> usize {
+    let mut hash_val = 0;
+    for &byte in s.as_bytes().iter() {
+        hash_val = (hash_val * RADIX + byte as usize) % MOD;
+    }
+    hash_val
+}
+
+/// Updates the rolling hash when shifting the search window.
+///
+/// # Arguments
+/// * `s` - The full text where the search is performed.
+/// * `old_idx` - The index of the character that is leaving the window.
+/// * `new_idx` - The index of the new character entering the window.
+/// * `old_hash` - The hash of the previous substring.
+/// * `radix_pow` - The precomputed value of RADIX^(n-1) % MOD.
+///
+/// # Returns
+/// The updated hash for the new substring.
+fn update_hash(
+    s: &str,
+    old_idx: usize,
+    new_idx: usize,
+    old_hash: usize,
+    radix_pow: usize,
+) -> usize {
+    let mut new_hash = old_hash;
+    let old_char = s.as_bytes()[old_idx] as usize;
+    let new_char = s.as_bytes()[new_idx] as usize;
+    new_hash = (new_hash + MOD - (old_char * radix_pow % MOD)) % MOD;
+    new_hash = (new_hash * RADIX + new_char) % MOD;
+    new_hash
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    macro_rules! test_cases {
+        ($($name:ident: $inputs:expr,)*) => {
+            $(
+                #[test]
+                fn $name() {
+                    let (text, pattern, expected) = $inputs;
+                    assert_eq!(rabin_karp(text, pattern), expected);
+                }
+            )*
+        };
+    }
+
+    test_cases! {
+        single_match_at_start: ("hello world", "hello", vec![0]),
+        single_match_at_end: ("hello world", "world", vec![6]),
+        single_match_in_middle: ("abc def ghi", "def", vec![4]),
+        multiple_matches: ("ababcabc", "abc", vec![2, 5]),
+        overlapping_matches: ("aaaaa", "aaa", vec![0, 1, 2]),
+        no_match: ("abcdefg", "xyz", vec![]),
+        pattern_is_entire_string: ("abc", "abc", vec![0]),
+        target_is_multiple_patterns: ("abcabcabc", "abc", vec![0, 3, 6]),
+        empty_text: ("", "abc", vec![]),
+        empty_pattern: ("abc", "", vec![]),
+        empty_text_and_pattern: ("", "", vec![]),
+        pattern_larger_than_text: ("abc", "abcd", vec![]),
+        large_text_small_pattern: (&("a".repeat(1000) + "b"), "b", vec![1000]),
+        single_char_match: ("a", "a", vec![0]),
+        single_char_no_match: ("a", "b", vec![]),
+        large_pattern_no_match: ("abc", "defghi", vec![]),
+        repeating_chars: ("aaaaaa", "aa", vec![0, 1, 2, 3, 4]),
+        special_characters: ("abc$def@ghi", "$def@", vec![3]),
+        numeric_and_alphabetic_mix: ("abc123abc456", "123abc", vec![3]),
+        case_sensitivity: ("AbcAbc", "abc", vec![]),
+    }
+}

--- a/__run_exp8/radixsort.lua
+++ b/__run_exp8/radixsort.lua
@@ -1,0 +1,34 @@
+return function(
+	radix -- number, defaults to 16
+)
+	radix = radix or 16
+	return function(list) -- in-place sorting function; can only handle positive integer numbers
+		if #list == 0 then
+			return
+		end
+		local div = 1
+		while true do
+			local by_digit = {}
+			local max_place = true
+			for i = 1, radix do
+				by_digit[i] = {}
+			end
+			for _, number in ipairs(list) do
+				local quotient = math.floor(number / div)
+				max_place = max_place and (quotient == 0)
+				table.insert(by_digit[(quotient % radix) + 1], number)
+			end
+			if max_place then -- quotients are all zero, highest-value number has been considered already
+				return
+			end
+			local index = 1
+			for _, numbers in ipairs(by_digit) do
+				for _, number in ipairs(numbers) do
+					list[index] = number
+					index = index + 1
+				end
+			end
+			div = div * radix
+		end
+	end
+end

--- a/__run_exp8/straightlines_test.go
+++ b/__run_exp8/straightlines_test.go
@@ -1,0 +1,70 @@
+package geometry
+
+import (
+	"testing"
+)
+
+func TestDistance(t *testing.T) {
+	p1 := Point{0, 0}
+	p2 := Point{3, 4}
+	var wantedDistance float64 = 5
+	var calculatedDistance float64 = Distance(&p1, &p2)
+	if calculatedDistance != wantedDistance {
+		t.Fatalf("Failed to calculate Distance.")
+	}
+}
+
+func TestSection(t *testing.T) {
+	p1 := Point{1, 0}
+	p2 := Point{5, 0}
+	wantedPoint := Point{3, 0}
+	calculatedPoint := Section(&p1, &p2, 1)
+	if calculatedPoint != wantedPoint {
+		t.Fatalf("Failed to calculate Section.")
+	}
+}
+
+func TestSlope(t *testing.T) {
+	line := Line{P1: Point{1, 2}, P2: Point{2, 4}}
+	var wantedSlope float64 = 2
+	var calculatedSlope float64 = Slope(&line)
+	if calculatedSlope != wantedSlope {
+		t.Fatalf("Failed to calculate Slope.")
+	}
+}
+
+func TestIntercept(t *testing.T) {
+	p := Point{0, 3}
+	var slope float64 = -5
+	var wantedIntercept float64 = 3
+	var calculatedIntercept float64 = YIntercept(&p, slope)
+	if calculatedIntercept != wantedIntercept {
+		t.Fatalf("Failed to calculate YIntercept.")
+	}
+}
+
+func TestIsParallel(t *testing.T) {
+	l1 := Line{P1: Point{1, 2}, P2: Point{2, 4}}
+	l2 := Line{P1: Point{25, 50}, P2: Point{50, 100}}
+	if !IsParallel(&l1, &l2) {
+		t.Fatalf("Failed to check if Parallel.")
+	}
+}
+
+func TestIsPerpendicular(t *testing.T) {
+	l1 := Line{P1: Point{1, 2}, P2: Point{2, 4}}
+	l2 := Line{P1: Point{2, 2}, P2: Point{4, 1}}
+	if !IsPerpendicular(&l1, &l2) {
+		t.Fatalf("Failed to check if Perpendicular.")
+	}
+}
+
+func TestPointDistance(t *testing.T) {
+	p := Point{1, 1}
+	equation := [3]float64{4, 3, 1}
+	var wantedDistance float64 = 1.6
+	var calculatedDistance float64 = PointDistance(&p, equation)
+	if calculatedDistance != wantedDistance {
+		t.Fatalf("Failed to calculate Point Distance.")
+	}
+}

--- a/__run_exp8/sum_of_harmonic_series.rs
+++ b/__run_exp8/sum_of_harmonic_series.rs
@@ -1,0 +1,40 @@
+// Author : cyrixninja
+// Sum of Harmonic Series :    Find the sum of n terms in an harmonic progression.  The calculation starts with the
+//                             first_term and loops adding the common difference of Arithmetic Progression by which
+//                             the given Harmonic Progression is linked.
+// Wikipedia Reference  :  https://en.wikipedia.org/wiki/Interquartile_range
+// Other References     :  https://the-algorithms.com/algorithm/sum-of-harmonic-series?lang=python
+
+pub fn sum_of_harmonic_progression(
+    first_term: f64,
+    common_difference: f64,
+    number_of_terms: i32,
+) -> f64 {
+    let mut arithmetic_progression = vec![1.0 / first_term];
+    let mut current_term = 1.0 / first_term;
+
+    for _ in 0..(number_of_terms - 1) {
+        current_term += common_difference;
+        arithmetic_progression.push(current_term);
+    }
+
+    let harmonic_series: Vec<f64> = arithmetic_progression
+        .into_iter()
+        .map(|step| 1.0 / step)
+        .collect();
+    harmonic_series.iter().sum()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_sum_of_harmonic_progression() {
+        assert_eq!(sum_of_harmonic_progression(1.0 / 2.0, 2.0, 2), 0.75);
+        assert_eq!(
+            sum_of_harmonic_progression(1.0 / 5.0, 5.0, 5),
+            0.45666666666666667
+        );
+    }
+}


### PR DESCRIPTION
11 Decided to archive the experimental bias-correction module as 'won't fix' due to a 400% increase in inference time during benchmarking. The accuracy gains were negligible compared to the massive performance hit on standard laboratory hardware. We will focus on more efficient normalization strategies instead.