### PR TITLE
Closes #99 Add explicit failure for deprecated input formats

### DIFF
--- a/__run_test2/CheckWordOccurrence.js
+++ b/__run_test2/CheckWordOccurrence.js
@@ -1,0 +1,27 @@
+/**
+ * @function checkWordOccurrence
+ * @description - this function count all the words in a sentence and return an word occurrence object
+ * @param {string} str
+ * @param {boolean} isCaseSensitive
+ * @returns {Object}
+ */
+const checkWordOccurrence = (str, isCaseSensitive = false) => {
+  if (typeof str !== 'string') {
+    throw new TypeError('The first param should be a string')
+  }
+
+  if (typeof isCaseSensitive !== 'boolean') {
+    throw new TypeError('The second param should be a boolean')
+  }
+
+  const modifiedStr = isCaseSensitive ? str.toLowerCase() : str
+
+  return modifiedStr
+    .split(/\s+/) // remove all spaces and distribute all word in List
+    .reduce((occurrence, word) => {
+      occurrence[word] = occurrence[word] + 1 || 1
+      return occurrence
+    }, {})
+}
+
+export { checkWordOccurrence }

--- a/__run_test2/SaddlebackSearchTest.java
+++ b/__run_test2/SaddlebackSearchTest.java
@@ -1,0 +1,85 @@
+package com.thealgorithms.searches;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+class SaddlebackSearchTest {
+
+    /**
+     * Test searching for an element that exists in the array.
+     */
+    @Test
+    void testFindElementExists() {
+        int[][] arr = {{-10, -5, -3, 4, 9}, {-6, -2, 0, 5, 10}, {-4, -1, 1, 6, 12}, {2, 3, 7, 8, 13}, {100, 120, 130, 140, 150}};
+
+        int[] result = SaddlebackSearch.find(arr, arr.length - 1, 0, 4);
+        assertArrayEquals(new int[] {0, 3}, result, "Element 4 should be found at (0, 3)");
+    }
+
+    /**
+     * Test searching for an element that does not exist in the array.
+     */
+    @Test
+    void testFindElementNotExists() {
+        int[][] arr = {{-10, -5, -3, 4, 9}, {-6, -2, 0, 5, 10}, {-4, -1, 1, 6, 12}, {2, 3, 7, 8, 13}, {100, 120, 130, 140, 150}};
+
+        int[] result = SaddlebackSearch.find(arr, arr.length - 1, 0, 1000);
+        assertArrayEquals(new int[] {-1, -1}, result, "Element 1000 should not be found");
+    }
+
+    /**
+     * Test searching for the smallest element in the array.
+     */
+    @Test
+    void testFindSmallestElement() {
+        int[][] arr = {{-10, -5, -3, 4, 9}, {-6, -2, 0, 5, 10}, {-4, -1, 1, 6, 12}, {2, 3, 7, 8, 13}, {100, 120, 130, 140, 150}};
+
+        int[] result = SaddlebackSearch.find(arr, arr.length - 1, 0, -10);
+        assertArrayEquals(new int[] {0, 0}, result, "Element -10 should be found at (0, 0)");
+    }
+
+    /**
+     * Test searching for the largest element in the array.
+     */
+    @Test
+    void testFindLargestElement() {
+        int[][] arr = {{-10, -5, -3, 4, 9}, {-6, -2, 0, 5, 10}, {-4, -1, 1, 6, 12}, {2, 3, 7, 8, 13}, {100, 120, 130, 140, 150}};
+
+        int[] result = SaddlebackSearch.find(arr, arr.length - 1, 0, 150);
+        assertArrayEquals(new int[] {4, 4}, result, "Element 150 should be found at (4, 4)");
+    }
+
+    /**
+     * Test searching in an empty array.
+     */
+    @Test
+    void testFindInEmptyArray() {
+        int[][] arr = {};
+
+        assertThrows(IllegalArgumentException.class, () -> { SaddlebackSearch.find(arr, 0, 0, 4); });
+    }
+
+    /**
+     * Test searching in a single element array that matches the search key.
+     */
+    @Test
+    void testFindSingleElementExists() {
+        int[][] arr = {{5}};
+
+        int[] result = SaddlebackSearch.find(arr, 0, 0, 5);
+        assertArrayEquals(new int[] {0, 0}, result, "Element 5 should be found at (0, 0)");
+    }
+
+    /**
+     * Test searching in a single element array that does not match the search key.
+     */
+    @Test
+    void testFindSingleElementNotExists() {
+        int[][] arr = {{5}};
+
+        int[] result = SaddlebackSearch.find(arr, 0, 0, 10);
+        assertArrayEquals(new int[] {-1, -1}, result, "Element 10 should not be found in single element array");
+    }
+}

--- a/__run_test2/xor.rs
+++ b/__run_test2/xor.rs
@@ -1,0 +1,50 @@
+pub fn xor_bytes(text: &[u8], key: u8) -> Vec<u8> {
+    text.iter().map(|c| c ^ key).collect()
+}
+
+pub fn xor(text: &str, key: u8) -> Vec<u8> {
+    xor_bytes(text.as_bytes(), key)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_simple() {
+        let test_string = "test string";
+        let ciphered_text = xor(test_string, 32);
+        assert_eq!(test_string.as_bytes(), xor_bytes(&ciphered_text, 32));
+    }
+
+    #[test]
+    fn test_every_alphabet_with_space() {
+        let test_string = "The quick brown fox jumps over the lazy dog";
+        let ciphered_text = xor(test_string, 64);
+        assert_eq!(test_string.as_bytes(), xor_bytes(&ciphered_text, 64));
+    }
+
+    #[test]
+    fn test_multi_byte() {
+        let test_string = "日本語";
+        let key = 42;
+        let ciphered_text = xor(test_string, key);
+        assert_eq!(test_string.as_bytes(), xor_bytes(&ciphered_text, key));
+    }
+
+    #[test]
+    fn test_zero_byte() {
+        let test_string = "The quick brown fox jumps over the lazy dog";
+        let key = b' ';
+        let ciphered_text = xor(test_string, key);
+        assert_eq!(test_string.as_bytes(), xor_bytes(&ciphered_text, key));
+    }
+
+    #[test]
+    fn test_invalid_byte() {
+        let test_string = "The quick brown fox jumps over the lazy dog";
+        let key = !0;
+        let ciphered_text = xor(test_string, key);
+        assert_eq!(test_string.as_bytes(), xor_bytes(&ciphered_text, key));
+    }
+}


### PR DESCRIPTION
99 Updated the normalization method configuration in the scRNA-seq YAML to clarify the use of LogNormalize vs. SCtransform. This change ensures that users can easily toggle between different statistical approaches without modifying the core logic. Added a comment section explaining the math behind each.